### PR TITLE
fix: SCALE_MODE value based on enum

### DIFF
--- a/src/SCALE_MODES.re
+++ b/src/SCALE_MODES.re
@@ -3,18 +3,19 @@
 
   The PIXI.settings.SCALE_MODE scale mode affects the default scaling mode of future operations. 
   It can be re-assigned to either LINEAR or NEAREST, depending upon suitability.
+  Ref: https://github.com/pixijs/pixi.js/blob/dev/packages/constants/src/index.ts#L267
  */
 [@bs.deriving jsConverter]
 type t = 
-  | [@bs.as 0] Linear
-  | [@bs.as 1] Nearest;
-
-/**
-  Smooth scaling
- */
-let linear = 0;
+  | [@bs.as 0] Nearest;
+  | [@bs.as 1] Linear
 
 /**
   Pixelating scaling
  */
-let nearest = 1;
+let nearest = 0;
+
+/**
+  Smooth scaling
+ */
+let linear = 1;

--- a/src/SCALE_MODES.re
+++ b/src/SCALE_MODES.re
@@ -1,14 +1,14 @@
 /**
   The scale modes that are supported by pixi.
 
-  The PIXI.settings.SCALE_MODE scale mode affects the default scaling mode of future operations. 
+  The PIXI.settings.SCALE_MODE scale mode affects the default scaling mode of future operations.
   It can be re-assigned to either LINEAR or NEAREST, depending upon suitability.
   Ref: https://github.com/pixijs/pixi.js/blob/dev/packages/constants/src/index.ts#L267
  */
 [@bs.deriving jsConverter]
-type t = 
-  | [@bs.as 0] Nearest;
-  | [@bs.as 1] Linear
+type t =
+  | [@bs.as 0] Nearest
+  | [@bs.as 1] Linear;
 
 /**
   Pixelating scaling


### PR DESCRIPTION
Fix: SCALE_MODE value as per pixi code
https://github.com/pixijs/pixi.js/blob/dev/packages/constants/src/index.ts#L267