### PR TITLE
chore: bumped up bs-webapi to v0.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "bs-pixi",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1167,6 +1167,11 @@
                 }
             }
         },
+        "bs-fetch": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/bs-fetch/-/bs-fetch-0.6.2.tgz",
+            "integrity": "sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg=="
+        },
         "bs-jest-dom": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/bs-jest-dom/-/bs-jest-dom-2.0.1.tgz",
@@ -1184,9 +1189,12 @@
             "dev": true
         },
         "bs-webapi": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.15.5.tgz",
-            "integrity": "sha512-6hruP0HIpXpa5pEoAlOBaKa97WodjN8zNA6TsxtInawTKiV7fXcSkkvnEP4yXfwU4OcGnBw8fuchWO4bUr7vuQ=="
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.19.1.tgz",
+            "integrity": "sha512-sRhkNdHFBxzoiLH+r8rhlW9XSafBbbGCkvsxtTJ1QMABEaHKj8TejwA7TuBZH2ZYL2ur3sk291ukkge5qFm3Uw==",
+            "requires": {
+                "bs-fetch": "^0.6.2"
+            }
         },
         "bser": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "reason-cli": "^3.3.3-macos-1"
     },
     "dependencies": {
-        "bs-webapi": "^0.15.5",
+        "bs-webapi": "0.19.1",
         "pixi.js": "^5.2.0"
     },
     "peerDependencies": {}


### PR DESCRIPTION
Ref: https://github.com/reasonml-community/bs-webapi-incubator/releases/tag/v0.19.1